### PR TITLE
Add UTF-8 meta tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var log = console.log
 log('<!DOCTYPE html>')
 log('<html>')
+log('<head><meta charset=utf-8></head>')
 log('<body></body>')
 log('<script language=javascript>')
 process.stdin.pipe(process.stdout)


### PR DESCRIPTION
Scripts with characters such as π (i.e. d3) will throw an error without it.
