### PR TITLE
Don't alter style and script bodies by prefixing them with newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,13 +29,13 @@ function indexhtmlify(opts) {
     s.push('<meta charset=utf-8></head>\n')
 
     if (opts.style) {
-        s.push('<style>\n')
+        s.push('<style>')
         s.push(require('fs').readFileSync(opts.style, 'utf8'))
         s.push('</style>\n')
     }
 
     s.push('<body></body>\n')
-    s.push('<script>\n')
+    s.push('<script>')
 
     return s
 }


### PR DESCRIPTION
Adding newlines to script and style bodies messes with Content Security Policy HTTP headers that contain checksums for scripts or styles. This PR removes the newlines and uses the data provided by upstream verbatim.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src

```
'<hash-algorithm>-<base64-value>'
```

A sha256, sha384 or sha512 hash of scripts or styles. The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style. When generating the hash, don't include the <script> or <style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace. See unsafe inline script for an example. In CSP 2.0 this applied only to inline scripts. CSP 3.0 allows it in the case of script-src for external scripts.